### PR TITLE
修复首次进入模板设计页面不显示编辑页面的bug

### DIFF
--- a/vendor/thinkcmf/cmf-app/src/admin/controller/ThemeController.php
+++ b/vendor/thinkcmf/cmf-app/src/admin/controller/ThemeController.php
@@ -947,9 +947,9 @@ class ThemeController extends AdminBaseController
      */
     public function design()
     {
+	$theme = $this->request->param('theme');
+        cookie('cmf_design_theme', $theme, 3);
         if ($this->request->isAjax()) {
-            $theme = $this->request->param('theme');
-            cookie('cmf_design_theme', $theme, 3);
             $this->success('success');
         } else {
             $content = hook_one('admin_theme_design_view');


### PR DESCRIPTION
问题位置：后台->模板管理->设计->编辑当前页功能
第一次打开页面时，点击 ‘编辑当前页‘ 按钮，打开是空白页面，再次刷新页面才可编辑。
经验证，第一次打开页面未设置cookie，js定时器轮询才设置cookie，标记为编辑状态。
修改代码，打开页面时就设置cookie